### PR TITLE
Wochenbericht: neutraler Rückblick statt Diagnose

### DIFF
--- a/main.py
+++ b/main.py
@@ -1066,6 +1066,7 @@ async def chat(user_id: str, chat_input: ChatInput):
         - Verbiete dir selbst: "lass es mich wissen", "ich bin für dich da", "klingt spannend!", passive Einladungen. Entweder konkret nachfragen oder gar nicht.
         - Keine Emojis.
         - Wenn der Nutzer etwas relativiert, korrigiert oder ein Thema als erledigt/nicht relevant signalisiert: vollständig akzeptieren und KEINE Folgefrage stellen. Thema ist damit beendet.
+        - Schlage KEINE To-Dos für berufliche Themen vor (Meetings, Arbeitsprojekte, Kundentermine, Präsentationen). Nur private Themen: Gesundheit, Sport, persönliche Ziele, soziale Kontakte.
 
         Antworte maximal 3 Sätze. Deine Antworten sollen knapp, direkt, motivierend oder kritisch sein.
         """
@@ -1110,7 +1111,7 @@ Ein Commitment ist NUR relevant wenn ALLE Kriterien erfüllt sind:
 1. Spezifische Aktion (nicht vage wie "ich will gesünder leben")
 2. Hat einen Zeitbezug oder ist zeitkritisch
 3. Nicht trivial (kein "ich gehe heute einkaufen", kein "ich trinke mehr Wasser")
-4. Relevant für Ziele, Karriere, Gesundheit oder persönliche Entwicklung
+4. Relevant für Ziele, Gesundheit oder persönliche Entwicklung — NICHT beruflich (keine Meetings, Arbeitsprojekte, Kundentermine, berufliche Präsentationen)
 
 Antworte NUR mit JSON:
 {{"commitment": false}} — wenn kein echtes Commitment

--- a/main.py
+++ b/main.py
@@ -1365,17 +1365,20 @@ async def automatischer_bericht(user_id: str = "1"):
             except Exception as e:
                 print(f"Fehler beim Cleanup der Konversationshistorie: {e}")
 
-    if bericht_typ is None and heute_utc.weekday() == 6:
-        monday_of_this_week = (heute_utc - datetime.timedelta(days=6)).replace(hour=0, minute=0, second=0, microsecond=0)
+    if bericht_typ is None:
+        # Letzten Sonntag ermitteln (oder heute, falls Sonntag)
+        days_since_sunday = (heute_utc.weekday() + 1) % 7
+        last_sunday = heute_utc - datetime.timedelta(days=days_since_sunday)
+        monday_of_last_week = (last_sunday - datetime.timedelta(days=6)).replace(hour=0, minute=0, second=0, microsecond=0)
         existing_weekly = supabase.table("long_term_memory") \
             .select("id") \
             .eq("user_id", user_id) \
             .eq("thema", "Wochenrückblick") \
-            .gte("timestamp", monday_of_this_week.isoformat() + 'Z') \
+            .gte("timestamp", monday_of_last_week.isoformat() + 'Z') \
             .execute().data
         if not existing_weekly:
             bericht_typ = "Wochenrückblick"
-            bericht_inhalt = await generiere_rueckblick("Wochen", 7, user_id, seit=monday_of_this_week.isoformat() + 'Z')
+            bericht_inhalt = await generiere_rueckblick("Wochen", 7, user_id, seit=monday_of_last_week.isoformat() + 'Z')
 
     if bericht_typ is None:
         return {"typ": None, "inhalt": "Heute wird kein Bericht generiert."}

--- a/main.py
+++ b/main.py
@@ -1646,10 +1646,11 @@ async def generiere_rueckblick(zeitraum: str, tage: int, user_id: str, seit: str
         zeitraum_label = f"Woche {montag} – {heute.strftime('%d.%m.%Y')}"
 
     system = f"""
-    Du bist ein persönlicher Beobachter und Coach. Fasse den {zeitraum} knapp zusammen.
-    Maximal 200 Wörter. Kein langer Fließtext, keine ausführlichen Abschnitte.
-    Struktur: 3-4 Stichpunkte zu Themen/Fortschritten, 1-2 Muster, maximal 2 konkrete nächste Schritte. Fertig.
-    Nutze den übergeordneten Kontext (Monats-/Quartalsbericht), um zu prüfen ob die aktuellen Aktivitäten zur größeren Richtung passen.
+    Du bist ein persönlicher Chronist. Schreibe einen knappen, nüchternen Rückblick — was war, nicht was fehlt oder verbessert werden sollte.
+    Keine Diagnosen, keine Ratschläge, keine "nächsten Schritte". Nur beschreiben was tatsächlich passiert ist.
+    Wenn wenig besprochen wurde, schreibe wenig — lieber 3 Sätze als aufgebauschte Stichpunkte.
+    Maximal 150 Wörter. Struktur: 2-4 Stichpunkte zu besprochenen Themen/Aktivitäten, optional 1 sachliche Beobachtung zu Mustern (neutral, nicht wertend).
+    Nutze den übergeordneten Kontext nur um einzuordnen ob aktuelle Themen zur größeren Richtung passen — kein Urteil.
 
     WICHTIG — Zeitliche Einordnung (Heute: {heute.strftime('%d. %B %Y')}):
     - Ereignisse und Termine die vor dem heutigen Datum lagen, sind VERGANGEN — schreibe sie im Präteritum


### PR DESCRIPTION
Wochenbericht schreibt nur auf was war — keine Diagnosen, keine Ratschläge, kürzer bei wenig Inhalt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAGn1Y4vC89DFfjrkgmNgX)_