### PR TITLE
Einstiegsfrage: Datumscheck für vergangene Ereignisse

### DIFF
--- a/main.py
+++ b/main.py
@@ -1646,10 +1646,13 @@ async def generiere_rueckblick(zeitraum: str, tage: int, user_id: str, seit: str
         zeitraum_label = f"Woche {montag} – {heute.strftime('%d.%m.%Y')}"
 
     system = f"""
-    Du bist ein persönlicher Chronist. Schreibe einen knappen, nüchternen Rückblick — was war, nicht was fehlt oder verbessert werden sollte.
-    Keine Diagnosen, keine Ratschläge, keine "nächsten Schritte". Nur beschreiben was tatsächlich passiert ist.
+    Du bist ein persönlicher Chronist. Schreibe einen knappen, nüchternen Rückblick — was war, nicht was fehlt.
     Wenn wenig besprochen wurde, schreibe wenig — lieber 3 Sätze als aufgebauschte Stichpunkte.
-    Maximal 150 Wörter. Struktur: 2-4 Stichpunkte zu besprochenen Themen/Aktivitäten, optional 1 sachliche Beobachtung zu Mustern (neutral, nicht wertend).
+    Maximal 150 Wörter. Struktur:
+    - 2-4 Stichpunkte zu besprochenen Themen/Aktivitäten (neutral beschreibend)
+    - 1 Satz: was gerade im Fokus steht
+    - 1 kurzer, konkreter Hinweis oder Beobachtung am Ende — kein allgemeiner Ratschlag, sondern etwas Spezifisches aus dieser Woche
+    Keine Problemdiagnosen, keine Listen von "nächsten Schritten".
     Nutze den übergeordneten Kontext nur um einzuordnen ob aktuelle Themen zur größeren Richtung passen — kein Urteil.
 
     WICHTIG — Zeitliche Einordnung (Heute: {heute.strftime('%d. %B %Y')}):

--- a/main.py
+++ b/main.py
@@ -545,6 +545,7 @@ async def start_interaction(user_id: str):
 
 
         # Kontext für GPT aufbauen
+        today_date_str = datetime.datetime.now().strftime('%d. %B %Y')
         context_for_gpt = "\nUser-Historie (letzte 30 Nachrichten):\n" + "\n".join(messages)
         if recent_ai_prompts_to_avoid:
             context_for_gpt += "\nKürzlich gestellte Fragen des Beraters:\n" + ", ".join(recent_ai_prompts_to_avoid)
@@ -554,6 +555,7 @@ async def start_interaction(user_id: str):
         context_for_gpt += routines_overview_context
         if routine_context_today:
             context_for_gpt += f"\nHeute oft verpasste Routinen: {routine_context_today}"
+        context_for_gpt += f"\n\nWICHTIG — Heute ist {today_date_str}. Bevor du ein Ereignis, Termin oder Vorhaben ansprichst: prüfe ob das genannte Datum vor dem heutigen Datum liegt. Wenn ja, frage NICHT nach Vorbereitung oder Plänen — sprich es höchstens als vergangene Erfahrung an."
 
         if mode == "todo_followup":
             prompt = f"""


### PR DESCRIPTION
Datumscheck in Einstiegsfrage-Kontext — keine Fragen über vergangene Ereignisse als wären sie bevorstehend.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAGn1Y4vC89DFfjrkgmNgX)_