### PR TITLE
Profil: veraltete Einträge automatisch löschen

### DIFF
--- a/main.py
+++ b/main.py
@@ -1646,10 +1646,13 @@ async def generiere_rueckblick(zeitraum: str, tage: int, user_id: str, seit: str
         zeitraum_label = f"Woche {montag} – {heute.strftime('%d.%m.%Y')}"
 
     system = f"""
-    Du bist ein persönlicher Chronist. Schreibe einen knappen, nüchternen Rückblick — was war, nicht was fehlt oder verbessert werden sollte.
-    Keine Diagnosen, keine Ratschläge, keine "nächsten Schritte". Nur beschreiben was tatsächlich passiert ist.
+    Du bist ein persönlicher Chronist. Schreibe einen knappen, nüchternen Rückblick — was war, nicht was fehlt.
     Wenn wenig besprochen wurde, schreibe wenig — lieber 3 Sätze als aufgebauschte Stichpunkte.
-    Maximal 150 Wörter. Struktur: 2-4 Stichpunkte zu besprochenen Themen/Aktivitäten, optional 1 sachliche Beobachtung zu Mustern (neutral, nicht wertend).
+    Maximal 150 Wörter. Struktur:
+    - 2-4 Stichpunkte zu besprochenen Themen/Aktivitäten (neutral beschreibend)
+    - 1 Satz: was gerade im Fokus steht
+    - 1 kurzer, konkreter Hinweis oder Beobachtung am Ende — kein allgemeiner Ratschlag, sondern etwas Spezifisches aus dieser Woche
+    Keine Problemdiagnosen, keine Listen von "nächsten Schritten".
     Nutze den übergeordneten Kontext nur um einzuordnen ob aktuelle Themen zur größeren Richtung passen — kein Urteil.
 
     WICHTIG — Zeitliche Einordnung (Heute: {heute.strftime('%d. %B %Y')}):

--- a/main.py
+++ b/main.py
@@ -147,7 +147,8 @@ async def extrahiere_und_speichere_profil_details(user_id: str, user_input: str,
     - Format Prozesse: Schlüssel = "Prozess_[Name]", Wert = "[Status] – [kurze Beschreibung]"
       Beispiele: "Prozess_Marathontraining": "laufend – Vorbereitung auf Hamburg Mai 2025", "Prozess_Jobsuche": "abgeschlossen Januar 2025"
     - Status IMMER aktuell halten: sobald etwas vorbei ist → "abgeschlossen [Zeitraum]"
-    - Vergangene Ereignisse erkennbar an: "war", "ist vorbei", "habe ich gemacht", "letztes Jahr", "ist beendet", "bin zurück" → immer "abgeschlossen" markieren
+    - Vergangene Ereignisse erkennbar an: "war", "ist vorbei", "habe ich gemacht", "letztes Jahr", "ist beendet", "bin zurück", "das war damals", "habe ich bereits" → immer "abgeschlossen" markieren
+    - WICHTIG: Wenn im bestehenden Profil ein Eintrag steht der offensichtlich veraltet ist (z.B. "bald nach X reisen" aber der Nutzer sagt es war letztes Jahr) → mit "abgeschlossen" zurückgeben damit er gelöscht wird
     - Zukünftige Ereignisse → "geplant für [Datum]"
 
     FAKTEN-KATEGORIEN (Beispiele):
@@ -189,19 +190,26 @@ async def extrahiere_und_speichere_profil_details(user_id: str, user_input: str,
         extracted_data_str = response.choices[0].message.content
         new_extracted_profile: Dict[str, str] = json.loads(extracted_data_str)
 
-
         # Temporäre Kategorien ausschließen
         EXCLUDED_CATEGORIES = ['Aktuelles_Datum']
         now = datetime.datetime.utcnow().isoformat() + 'Z'
 
-        records = [
-            {"user_id": user_id, "attribute_name": key, "attribute_value": value, "last_updated": now}
-            for key, value in new_extracted_profile.items()
-            if key not in EXCLUDED_CATEGORIES
-        ]
+        to_upsert = []
+        to_delete = []
 
-        if records:
-            supabase.table("profile").upsert(records).execute()
+        for key, value in new_extracted_profile.items():
+            if key in EXCLUDED_CATEGORIES:
+                continue
+            if isinstance(value, str) and "abgeschlossen" in value.lower():
+                to_delete.append(key)
+            else:
+                to_upsert.append({"user_id": user_id, "attribute_name": key, "attribute_value": value, "last_updated": now})
+
+        if to_upsert:
+            supabase.table("profile").upsert(to_upsert).execute()
+
+        for key in to_delete:
+            supabase.table("profile").delete().eq("user_id", user_id).eq("attribute_name", key).execute()
 
 
     except json.JSONDecodeError as e:

--- a/main.py
+++ b/main.py
@@ -545,6 +545,7 @@ async def start_interaction(user_id: str):
 
 
         # Kontext für GPT aufbauen
+        today_date_str = datetime.datetime.now().strftime('%d. %B %Y')
         context_for_gpt = "\nUser-Historie (letzte 30 Nachrichten):\n" + "\n".join(messages)
         if recent_ai_prompts_to_avoid:
             context_for_gpt += "\nKürzlich gestellte Fragen des Beraters:\n" + ", ".join(recent_ai_prompts_to_avoid)
@@ -554,6 +555,7 @@ async def start_interaction(user_id: str):
         context_for_gpt += routines_overview_context
         if routine_context_today:
             context_for_gpt += f"\nHeute oft verpasste Routinen: {routine_context_today}"
+        context_for_gpt += f"\n\nWICHTIG — Heute ist {today_date_str}. Bevor du ein Ereignis, Termin oder Vorhaben ansprichst: prüfe ob das genannte Datum vor dem heutigen Datum liegt. Wenn ja, frage NICHT nach Vorbereitung oder Plänen — sprich es höchstens als vergangene Erfahrung an."
 
         if mode == "todo_followup":
             prompt = f"""


### PR DESCRIPTION
Veraltete Profil-Einträge werden automatisch gelöscht wenn die Extraktion sie als abgeschlossen erkennt. Wichtige Ereignisse bleiben in long_term_memory erhalten.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAGn1Y4vC89DFfjrkgmNgX)_